### PR TITLE
Bump dependencies to support GHC >= 9.4

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Setup Haskell
         id: setup-haskell-cabal
-        uses: haskell-actions/setup@2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: 9.8.4
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Haskell
         id: setup-haskell-cabal
-        uses: actions/setup-haskell@v1.1.3
+        uses: haskell-actions/setup@2
         with:
-          ghc-version: 8.8
+          ghc-version: 9.8.4
 
       - name: Cabal Check
         run: cabal check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,15 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.2"]
-        ghc: ["8.6.5", "8.8.4", "8.10.2"]
+        cabal: ["3.12.1.0"]
+        ghc: ["9.6.7", "9.8.4", "9.10.2"]
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Haskell
         id: setup-haskell-cabal
-        uses: actions/setup-haskell@v1.1.3
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -28,7 +28,7 @@ jobs:
           cabal freeze
 
       - name: Cache ~/.cabal/store
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: cabal test
 
       - name: Upload Build Logs on Failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs-${{ matrix.os }}-ghc${{ matrix.ghc }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /TAGS
 /.stack-work/
 /.cabal/
+dist-newstyle/
+*.local

--- a/addy.cabal
+++ b/addy.cabal
@@ -9,7 +9,7 @@ copyright:          Copyright (c) 2019-2020 Peter Jones
 homepage:           https://github.com/pjones/addy
 bug-reports:        https://github.com/pjones/addy/issues
 category:           Text
-tested-with:        GHC ==8.6.5 || ==8.8.4 || ==8.10.2
+tested-with:        GHC ==9.4.8 || ==9.6.7 || ==9.8.4 || ==9.10.2
 build-type:         Simple
 synopsis:
   A full-featured library for parsing, validating, and rendering email addresses
@@ -71,15 +71,15 @@ common options
 --------------------------------------------------------------------------------
 common dependencies
   build-depends:
-    , attoparsec            ^>=0.13
-    , base                  >=4.9   && <5.0
-    , bytestring            >=0.10  && <0.12
-    , ip                    >=1.5.1 && <1.8
-    , lens                  >=4.17  && <5.0
-    , relude                >=0.6   && <0.8
-    , text                  ^>=1.2
-    , text-icu              ^>=0.7
-    , validation-selective  ^>=0.1
+    , attoparsec            >=0.13    && <0.15
+    , base                  >=4.9     && <5.0
+    , bytestring            >=0.10    && <0.13
+    , ip                    >=1.5.1   && <1.8
+    , lens                  >=4.17    && <5.4
+    , relude                >=0.6     && <2.0
+    , text                  >=1.2     && <3.0
+    , text-icu              >=0.7     && <0.9
+    , validation-selective  >=0.1.0.0 && <0.3
 
   mixins:
     base hiding (Prelude),
@@ -111,11 +111,11 @@ test-suite test
   build-depends:
     , addy
     , aeson           >=1.4
-    , hedgehog        ^>=1.0
+    , hedgehog        >=1.0  && <2.0
     , http-types      >=0.12
     , tasty           >=1.1  && <1.5
-    , tasty-hedgehog  ^>=1.0
-    , tasty-hunit     ^>=0.10
+    , tasty-hedgehog  >=1.0  && <1.5
+    , tasty-hunit     >=0.10 && <0.11
 
 --------------------------------------------------------------------------------
 -- test-suite doctests

--- a/addy.cabal
+++ b/addy.cabal
@@ -78,7 +78,7 @@ common dependencies
     , lens                  >=4.17    && <5.4
     , relude                >=0.6     && <2.0
     , text                  >=1.2     && <3.0
-    , text-icu              >=0.7     && <0.9
+    , unicode-transforms    >=0.4.0.1 && <0.5
     , validation-selective  >=0.1.0.0 && <0.3
 
   mixins:

--- a/src/Addy/Internal/Validation.hs
+++ b/src/Addy/Internal/Validation.hs
@@ -28,9 +28,12 @@ where
 
 import Addy.Internal.Char
 import Addy.Internal.Types
+
+
 import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
-import qualified Data.Text.ICU as ICU
+
+import Data.Text.ICU.Normalize2 (nfc)
 import Validation
 
 -- | Validate a single host name.  Each host name in a domain name
@@ -57,7 +60,7 @@ import Validation
 -- @since 0.1.0.0
 validateHostName :: Text -> Validation (NonEmpty Error) HostName
 validateHostName content =
-  let content' = Text.toLower (ICU.normalize ICU.NFC content)
+  let content' = Text.toLower $ nfc content
    in HN content'
         <$ ( validateNotPrefix "-" content'
                *> validateNotSuffix "-" content'
@@ -100,7 +103,7 @@ validateDomainName name =
 validateLocalPart ::
   Text -> Validation (NonEmpty Error) LocalPart
 validateLocalPart content =
-  let content' = ICU.normalize ICU.NFC content
+  let content' = nfc content
    in LP content'
         <$ ( validateLength 1 64 content'
                *> validateAllowedChars allowedChar content'

--- a/src/Addy/Internal/Validation.hs
+++ b/src/Addy/Internal/Validation.hs
@@ -33,7 +33,7 @@ import Addy.Internal.Types
 import qualified Data.ByteString as ByteString
 import qualified Data.Text as Text
 
-import Data.Text.ICU.Normalize2 (nfc)
+import Data.Text.Normalize (NormalizationMode(..), normalize)
 import Validation
 
 -- | Validate a single host name.  Each host name in a domain name
@@ -60,7 +60,7 @@ import Validation
 -- @since 0.1.0.0
 validateHostName :: Text -> Validation (NonEmpty Error) HostName
 validateHostName content =
-  let content' = Text.toLower $ nfc content
+  let content' = Text.toLower $ normalize NFC content
    in HN content'
         <$ ( validateNotPrefix "-" content'
                *> validateNotSuffix "-" content'
@@ -103,7 +103,7 @@ validateDomainName name =
 validateLocalPart ::
   Text -> Validation (NonEmpty Error) LocalPart
 validateLocalPart content =
-  let content' = nfc content
+  let content' = normalize NFC content
    in LP content'
         <$ ( validateLength 1 64 content'
                *> validateAllowedChars allowedChar content'

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -54,9 +54,12 @@ data IsEmailCat
 isEmailTests :: IO [(IsEmailTest, IsEmailCat)]
 isEmailTests = do
   let fileName = "test/isemail.json"
-  tests <- (Aeson.decode <$> readFileLBS fileName) >>= \case
-    Nothing -> assertFailure "failed to load the isemail.json file"
-    Just ts -> pure ts
+  tests <- readFileLBS fileName
+      >>=
+        (\case
+           Nothing -> assertFailure "failed to load the isemail.json file"
+           Just ts -> pure ts)
+          . Aeson.decode
   pure $ map (\t -> (decodeAddr t, decodeCat t)) tests
 
 -- | The XSL file URL-encodes the email addresses.  Additionally, the

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -229,7 +229,7 @@ allowedChar c = isAscii c || utf8NonAscii c
 unicode :: Gen Char
 unicode =
   Gen.frequency
-    [ (55296, Gen.element "!#$%&'*+-/=?^_`{|}~"),
+    [ (55296, Gen.element ("!#$%&'*+-/=?^_`{|}~" :: String)),
       (55296, Gen.alphaNum),
       (8190, Gen.filter isPrint (Gen.enum (chr 0xc2) maxBound))
     ]


### PR DESCRIPTION
Closes #8 
Closes #7

Changes include:
- Bump dependencies to enable build with GHCs >= 9.4.8
- Update github actions
- Replace `text-icu` with `unicode-transforms` package.